### PR TITLE
remove mention to map

### DIFF
--- a/en/starter/faq.md
+++ b/en/starter/faq.md
@@ -19,7 +19,6 @@ as you wish, in any directory structure you prefer. View the following
 examples for inspiration:
 
 * [Route listings](https://github.com/strongloop/express/blob/4.13.1/examples/route-separation/index.js#L32-47)
-* [Route map](https://github.com/strongloop/express/blob/4.13.1/examples/route-map/index.js#L52-L66)
 * [MVC style controllers](https://github.com/strongloop/express/tree/master/examples/mvc)
 
 Also, there are third-party extensions for Express, which simplify some of these patterns:


### PR DESCRIPTION
since it doesn't work with 4.13.4

while reading the doc, and following everything to learn express. I found the `app.map` method, isn't defined anymore.. Print screen http://cl.ly/3z1O1D2q2o2t

code examples from https://github.com/expressjs/express/blob/4.13.1/examples/route-map/index.js#L28-L66

using "express": "^4.13.4"
